### PR TITLE
Fix url to match with QR

### DIFF
--- a/dev-site.yml
+++ b/dev-site.yml
@@ -4,7 +4,7 @@ runtime:
 site:
   title: Summit-Connect-Madrid-OCPVirt-OADP
   url: https://github.com/rhcs-workshops/summit-connect-madrid-ocpvirt-oadp
-  start_page: template-tutorial::index.adoc
+  start_page: summit-ocpvirt-oadp-lab::index.adoc
 
 content:
   sources:

--- a/dev-site.yml
+++ b/dev-site.yml
@@ -4,7 +4,7 @@ runtime:
 site:
   title: Summit-Connect-Madrid-OCPVirt-OADP
   url: https://github.com/rhcs-workshops/summit-connect-madrid-ocpvirt-oadp
-  start_page: summit-connect-madrid-ocpvirt-oadp::index.adoc
+  start_page: template-tutorial::index.adoc
 
 content:
   sources:

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -1,5 +1,5 @@
-name: summit-connect-madrid-ocpvirt-oadp
-title: Backup y Restore de máquinas virtuales
+name: template-tutorial
+title: Summit Connect Madrid - Backup y Restore de Máquinas Virtuales
 version: master
 nav:
   - modules/ROOT/nav.adoc

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -1,4 +1,4 @@
-name: template-tutorial
+name: summit-ocpvirt-oadp-lab
 title: Summit Connect Madrid - Backup y Restore de Máquinas Virtuales
 version: master
 nav:


### PR DESCRIPTION
This PR will create the following URI to access the content:

`/template-tutorial/index.html` used by the QR of the event.

instead of the current one: `/summit-connect-madrid-ocpvirt-oadp/index.html`

